### PR TITLE
Fix typo in config comment

### DIFF
--- a/ulc/config.lua
+++ b/ulc/config.lua
@@ -57,7 +57,7 @@ Config = {
         maxExpiration = 8,
     },
 
-    -- Import confiurations here
+    -- Import configurations here
     -- Add the resource names of vehicle resources that include a ulc.lua config file
     ExternalVehResources = {
         -- ex. "my-police-vehicle",


### PR DESCRIPTION
## Summary
- correct `confiurations` typo in `ulc/config.lua`

## Testing
- `grep -n "Import" -n ulc/config.lua`

------
https://chatgpt.com/codex/tasks/task_e_684c63f50118832d95484c9c8ab8b494