### PR TITLE
Fix horn extras hold/restore bug, lock stage changes during horn hold, add fake environmental scene lights

### DIFF
--- a/example.ulc.lua
+++ b/example.ulc.lua
@@ -19,9 +19,11 @@ return {names = {""},
     dExtras = {}
   },
   hornConfig = {
-    useHorn = false,
+    useHorn = true,
     hornExtras = {},
-    disableExtras = {}
+    disableExtras = {},
+    holdDelay = 1500,        -- optional override, in milliseconds, Default 1.5sec (1500ms)
+    extraHoldTime = 5,      -- optional override, in seconds, Default 5sec (5000ms)
   },
   brakeConfig = {
     useBrakes = false,
@@ -57,5 +59,14 @@ return {names = {""},
     useDefaults = false,
     enableKeys = {},
     disableKeys = {}
-  }
+  },
+  fakeEnvConfig = {
+    useFakeEnv = true, -- opt-in per vehicle, off by default
+    lights = {
+      { extra = 10, direction = 'left' },  -- left alley
+      { extra = 11, direction = 'tk' },    -- take-down
+      { extra = 12, direction = 'right' }, -- right alley
+    }
+  },
+}
 }

--- a/ulc/client/c_buttons.lua
+++ b/ulc/client/c_buttons.lua
@@ -56,7 +56,11 @@ end)
 -- change specified extra, and if not extraOnly, and extra is in a button, act on the linked and off extras as well, acts recursively;
 -- action 0 enables, 1 disables, 2 toggles;
 -- updates ui whenever extra is used in a button
-function ULC:SetStage(extra, action, playSound, extraOnly, repair, forceChange, forceUi, allowOutside)
+-- hornOverride: bypasses the horn-active lock below. Used internally by
+-- c_horn.lua to change its own extras while active, and by the fake env
+-- (scene) lights in c_lights.lua so those stay toggleable during horn
+-- extras/Intersection Mode. Don't pass this true from anywhere else.
+function ULC:SetStage(extra, action, playSound, extraOnly, repair, forceChange, forceUi, allowOutside, hornOverride)
     ----------
     -- checks
     if not MyVehicle then
@@ -65,6 +69,13 @@ function ULC:SetStage(extra, action, playSound, extraOnly, repair, forceChange, 
     end
     if not allowOutside and not IsPedInAnyVehicle(PlayerPedId(), false) then
         print("[ULC:SetStage()] Player must be in a vehicle, or allowOutside must be true.")
+        return false
+    end
+    -- horn extras (Intersection Mode) currently own the extras - lock out
+    -- every other source of stage changes so nothing can stomp the horn
+    -- pattern while it's active. c_horn.lua bypasses this via hornOverride.
+    if not hornOverride and ULC.IsHornExtrasActive and ULC:IsHornExtrasActive() then
+        print("[ULC:SetStage()] Blocked - horn extras are currently active.")
         return false
     end
 

--- a/ulc/client/c_horn.lua
+++ b/ulc/client/c_horn.lua
@@ -2,6 +2,22 @@
 
 local extraStates = {}
 
+-- generation counter used to invalidate stale delayed threads when the
+-- player presses/releases the horn key rapidly, so an old timer can't
+-- turn extras on/off after a newer press has already changed state
+local hornGeneration = 0
+
+-- true only once extras have actually been forced on and are still
+-- waiting to be restored. This is intentionally separate from
+-- hornGeneration: hornGeneration exists to cancel stale timers, hornActive
+-- exists to make sure we never re-capture "original" extra states while
+-- the horn extras are already active (that would overwrite the real
+-- original state with the horn-on state, so the eventual restore would
+-- leave extras stuck in the wrong config), and to make sure holding
+-- time never stacks - every release always starts a single fresh
+-- extraHoldTime countdown rather than adding to one already running.
+local hornActive = false
+
 local function GetPreviousStateByExtra(extra)
     for k, v in pairs(extraStates) do
         --print(v.extra, v.state)
@@ -12,56 +28,142 @@ local function GetPreviousStateByExtra(extra)
     end
 end
 
-function SetHornExtras(newState)
-    -- print('SetHornExtras: ' .. newState)
-    if newState == 0 then
-        for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
-            local extraState = {
-                extra = extra,
-                state = IsVehicleExtraTurnedOn(MyVehicle, extra)
-            }
-            table.insert(extraStates, extraState)
-            ULC:SetStage(extra, 0, false, true, false, false, true, false)
-        end
-        if not MyVehicleConfig.hornConfig.disableExtras then return end
+-- resolves per-vehicle overrides, falling back to the global defaults
+local function GetHoldDelay()
+    local cfg = MyVehicleConfig.hornConfig
+    if cfg.holdDelay ~= nil then return cfg.holdDelay end
+    return Config.HornSettings.defaultHoldDelay
+end
+
+local function GetExtraHoldTime()
+    local cfg = MyVehicleConfig.hornConfig
+    if cfg.extraHoldTime ~= nil then return cfg.extraHoldTime end
+    return Config.HornSettings.defaultExtraHoldTime
+end
+
+-- Turns horn extras on and captures the pre-horn state so it can be
+-- restored later. Guarded by hornActive so that re-pressing the horn key
+-- while extras are already active (e.g. mashing it, or pressing again
+-- before the previous release's restore timer fired) can never overwrite
+-- the originally captured states with the "horn on" states.
+local function ApplyHornExtrasOn()
+    if hornActive then return end
+
+    extraStates = {}
+
+    for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
+        local extraState = {
+            extra = extra,
+            state = IsVehicleExtraTurnedOn(MyVehicle, extra)
+        }
+        table.insert(extraStates, extraState)
+        ULC:SetStage(extra, 0, false, true, false, false, true, false, true)
+    end
+
+    if MyVehicleConfig.hornConfig.disableExtras then
         for _, extra in pairs(MyVehicleConfig.hornConfig.disableExtras) do
             local extraState = {
                 extra = extra,
                 state = IsVehicleExtraTurnedOn(MyVehicle, extra)
             }
             table.insert(extraStates, extraState)
-            ULC:SetStage(extra, 1, false, true, false, false, true, false)
+            ULC:SetStage(extra, 1, false, true, false, false, true, false, true)
         end
-    elseif newState == 1 then
-        for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
-            local prevState = GetPreviousStateByExtra(extra)
-            if not prevState then
-                ULC:SetStage(extra, 1, false, true, false, false, true, false)
-            end
+    end
+
+    hornActive = true
+end
+
+-- Restores extras to the state captured in ApplyHornExtrasOn. Guarded by
+-- hornActive so it's only ever meaningful once, matching ApplyHornExtrasOn.
+local function RestoreHornExtrasOff()
+    if not hornActive then return end
+
+    for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
+        local prevState = GetPreviousStateByExtra(extra)
+        if not prevState then
+            ULC:SetStage(extra, 1, false, true, false, false, true, false, true)
         end
-        if not MyVehicleConfig.hornConfig.disableExtras then return end
+    end
+
+    if MyVehicleConfig.hornConfig.disableExtras then
         for _, extra in pairs(MyVehicleConfig.hornConfig.disableExtras) do
             local prevState = GetPreviousStateByExtra(extra)
             if prevState then
-                ULC:SetStage(extra, 0, false, true, false, false, true, false)
+                ULC:SetStage(extra, 0, false, true, false, false, true, false, true)
             end
         end
     end
+
+    extraStates = {}
+    hornActive = false
+end
+
+-- Exposed so other scripts (e.g. park pattern / intersection mode) can
+-- check whether horn extras currently own the extras and skip their own
+-- toggling while that's true, instead of fighting the horn for control.
+function ULC:IsHornExtrasActive()
+    return hornActive
 end
 
 RegisterCommand('+ulc:horn', function()
-    --print('horn')
-    extraStates = {}
+    if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
 
-    if MyVehicle and MyVehicleConfig.hornConfig.useHorn then
-        SetHornExtras(0)
+    hornGeneration = hornGeneration + 1
+    local myGeneration = hornGeneration
+
+    -- extras are already active - this press just cancelled any pending
+    -- restore timer (via the generation bump above). Don't re-capture
+    -- state and don't start another on-delay, or the real "before horn"
+    -- state would get lost.
+    if hornActive then return end
+
+    local holdDelay = GetHoldDelay()
+
+    if holdDelay <= 0 then
+        ApplyHornExtrasOn()
+        return
     end
+
+    CreateThread(function()
+        Wait(holdDelay)
+        -- bail if the key was released (or pressed again) before the delay finished
+        if myGeneration ~= hornGeneration then return end
+        if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
+
+        ApplyHornExtrasOn()
+    end)
 end)
 
 RegisterCommand('-ulc:horn', function()
-    if MyVehicle and MyVehicleConfig.hornConfig.useHorn then
-        SetHornExtras(1)
+    if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
+
+    hornGeneration = hornGeneration + 1
+    local myGeneration = hornGeneration
+
+    -- the horn never actually triggered (released before holdDelay elapsed)
+    -- nothing to restore
+    if not hornActive then return end
+
+    local extraHoldTime = GetExtraHoldTime()
+
+    if extraHoldTime <= 0 then
+        RestoreHornExtrasOff()
+        return
     end
+
+    -- every release starts exactly one fresh countdown. If the horn gets
+    -- pressed and released again before this fires, the generation bump
+    -- from that later release invalidates this thread and starts its own
+    -- - the hold time never adds up, it just restarts from full each time.
+    CreateThread(function()
+        Wait(extraHoldTime * 1000)
+        -- bail if the horn was pressed again before the hold time finished,
+        -- that press's own logic now owns restoring state
+        if myGeneration ~= hornGeneration then return end
+
+        RestoreHornExtrasOff()
+    end)
 end)
 
 RegisterKeyMapping('+ulc:horn', 'ULC: Activate Horn Extras', 'keyboard', 'e')

--- a/ulc/client/c_lights.lua
+++ b/ulc/client/c_lights.lua
@@ -1,0 +1,198 @@
+--[[
+  Fake Environmental Lights
+  --------------------------
+  Toggles a light-head extra's mesh only (no real environmental lighting
+  running behind it) and draws a real point light near the vehicle in that
+  light's direction, sized and positioned to read as a proper pool of
+  light rather than a dim blob - meant for things like TKDs/alleys where
+  you don't want the cost of a real environmental extra running full time.
+
+  Synced to nearby players via an entity state bag on the vehicle, so
+  passengers/bystanders see the same fake light the driver does, not just
+  the driver.
+]]
+
+print("[ULC] Lights (Fake Env) Loaded")
+
+local STATEBAG_KEY = 'ulc:fakeLights'
+
+-- vehicle handle -> { [extra] = direction, ... }
+-- covers both our own vehicle and any nearby synced vehicles
+local vehicleLightStates = {}
+
+-------------------
+-- Helpers
+-------------------
+
+local function getFakeEnvChecksPass()
+  if not Config.FakeEnvSettings.enabled then return false end
+  if not MyVehicle then return false end
+  if not MyVehicleConfig.fakeEnvConfig then return false end
+  if not MyVehicleConfig.fakeEnvConfig.useFakeEnv then return false end
+  if not MyVehicleConfig.fakeEnvConfig.lights then return false end
+  return true
+end
+
+local function getLightConfigByDirection(direction)
+  for _, v in pairs(MyVehicleConfig.fakeEnvConfig.lights) do
+    if v.direction == direction then return v end
+  end
+  return nil
+end
+
+-- computes the world position the light sits at for a given direction -
+-- left/right offset out to the side of the vehicle, tk (take-down) offsets
+-- forward, all raised up above the vehicle so it reads as a light source
+-- sitting above/beside it rather than something glued to the bodywork
+local function getLightOrigin(vehicle, direction)
+  local s = Config.FakeEnvSettings
+  local sideOffset, frontOffset = 0.0, 0.0
+
+  if direction == 'left' then
+    sideOffset = -s.sideDistance
+  elseif direction == 'right' then
+    sideOffset = s.sideDistance
+  elseif direction == 'tk' then
+    frontOffset = s.frontDistance
+  end
+
+  return GetOffsetFromEntityInWorldCoords(vehicle, sideOffset, frontOffset, s.heightOffset)
+end
+
+local function pushOwnStatebag()
+  if not MyVehicle then return end
+  Entity(MyVehicle).state:set(STATEBAG_KEY, vehicleLightStates[MyVehicle] or {}, true)
+end
+
+-------------------
+-- Toggle logic (local vehicle only - other players just receive our state bag)
+-------------------
+
+function ULC:ToggleFakeEnvLight(direction)
+  if not getFakeEnvChecksPass() then return end
+
+  local lightCfg = getLightConfigByDirection(direction)
+  if not lightCfg then
+    print("[ULC:ToggleFakeEnvLight] No fake env light configured for direction: " .. tostring(direction))
+    return
+  end
+
+  -- extraOnly = true, forceUi = true: toggle only this extra's mesh, don't
+  -- chain into linked/opposite/off extras or stage logic. Purely visual.
+  -- hornOverride = true: fake env/scene lights are meant to stay usable
+  -- even while horn extras (Intersection Mode) are active.
+  ULC:SetStage(lightCfg.extra, 2, true, true, false, false, true, false, true)
+
+  vehicleLightStates[MyVehicle] = vehicleLightStates[MyVehicle] or {}
+
+  if IsVehicleExtraTurnedOn(MyVehicle, lightCfg.extra) then
+    vehicleLightStates[MyVehicle][lightCfg.extra] = direction
+  else
+    vehicleLightStates[MyVehicle][lightCfg.extra] = nil
+  end
+
+  pushOwnStatebag()
+end
+
+-- called whenever the vehicle changes/despawns so we don't try to draw
+-- lights against a stale/invalid vehicle handle, and so the old vehicle's
+-- state bag is cleared for other players
+local lastVehicle = nil
+AddEventHandler('ulc:checkVehicle', function()
+  if lastVehicle and DoesEntityExist(lastVehicle) then
+    vehicleLightStates[lastVehicle] = nil
+    Entity(lastVehicle).state:set(STATEBAG_KEY, {}, true)
+  end
+  lastVehicle = MyVehicle
+
+  -- ask the server to sanity-check this vehicle's fakeEnvConfig, results show
+  -- up in the server console (see server/s_lights.lua)
+  if MyVehicleConfig and MyVehicleConfig.fakeEnvConfig and MyVehicleConfig.fakeEnvConfig.useFakeEnv then
+    TriggerServerEvent('ulc:lights:reportConfig', GetCurrentResourceName(), MyVehicleConfig.fakeEnvConfig)
+  end
+end)
+
+-------------------
+-- Remote sync (other players' vehicles)
+-------------------
+
+AddStateBagChangeHandler(STATEBAG_KEY, nil, function(bagName, _, value)
+  local vehicle = GetEntityFromStateBagName(bagName)
+  if not vehicle or vehicle == 0 then return end
+  -- our own vehicle is driven locally by the toggle function above, ignore echoes
+  if vehicle == MyVehicle then return end
+
+  if value and next(value) then
+    vehicleLightStates[vehicle] = value
+  else
+    vehicleLightStates[vehicle] = nil
+  end
+end)
+
+-------------------
+-- Draw loop
+-------------------
+
+CreateThread(function()
+  while true do
+    local sleep = 250
+
+    if next(vehicleLightStates) then
+      sleep = 0
+
+      local playerCoords = GetEntityCoords(PlayerPedId())
+      local s = Config.FakeEnvSettings
+
+      for vehicle, lights in pairs(vehicleLightStates) do
+        if DoesEntityExist(vehicle) then
+          local vehCoords = GetEntityCoords(vehicle)
+
+          if #(playerCoords - vehCoords) <= s.drawRange then
+            for extra, direction in pairs(lights) do
+              if IsVehicleExtraTurnedOn(vehicle, extra) then
+                local origin = getLightOrigin(vehicle, direction)
+                DrawLightWithRange(
+                  origin.x, origin.y, origin.z,
+                  s.color.r, s.color.g, s.color.b,
+                  s.lightRange, s.lightIntensity
+                )
+              elseif vehicle == MyVehicle then
+                -- our own extra was turned off some other way (blackout, respray) - clean up and re-sync
+                lights[extra] = nil
+                pushOwnStatebag()
+              end
+            end
+          end
+        else
+          -- vehicle despawned/out of range, drop it
+          vehicleLightStates[vehicle] = nil
+        end
+      end
+    end
+
+    Wait(sleep)
+  end
+end)
+
+-------------------
+-- Keybinds
+-------------------
+-- keys are read from Config.FakeEnvSettings.defaultKeys so server owners can
+-- change the default bind without editing this file. Players can still
+-- rebind in FiveM's keybind settings (Ultimate Lighting Controls category)
+-- same as every other ULC keybind.
+
+RegisterKeyMapping('ulc:fakeenv_left', 'ULC: Toggle Fake Left Alley Light', 'keyboard', Config.FakeEnvSettings.defaultKeys.left)
+RegisterCommand('ulc:fakeenv_left', function()
+  ULC:ToggleFakeEnvLight('left')
+end)
+
+RegisterKeyMapping('ulc:fakeenv_tk', 'ULC: Toggle Fake Take-Down Light', 'keyboard', Config.FakeEnvSettings.defaultKeys.tk)
+RegisterCommand('ulc:fakeenv_tk', function()
+  ULC:ToggleFakeEnvLight('tk')
+end)
+
+RegisterKeyMapping('ulc:fakeenv_right', 'ULC: Toggle Fake Right Alley Light', 'keyboard', Config.FakeEnvSettings.defaultKeys.right)
+RegisterCommand('ulc:fakeenv_right', function()
+  ULC:ToggleFakeEnvLight('right')
+end)

--- a/ulc/client/c_park.lua
+++ b/ulc/client/c_park.lua
@@ -42,6 +42,12 @@ end)
 
 AddEventHandler('ulc:vehPark', function()
     if Lights then
+        -- horn extras currently own the extras (Intersection Mode / horn
+        -- hold is active) - don't fight it for control. The periodic
+        -- ulc:checkParkState poll will re-evaluate and catch this vehicle
+        -- up to the correct parked/driving state once the horn releases.
+        if ULC.IsHornExtrasActive and ULC:IsHornExtrasActive() then return end
+
         --print('[ulc:vehPark] My vehicle is parked.')
         parked = true
 
@@ -134,6 +140,9 @@ end)
 
 AddEventHandler('ulc:vehDrive', function()
     if Lights then
+        -- see the matching guard in ulc:vehPark above
+        if ULC.IsHornExtrasActive and ULC:IsHornExtrasActive() then return end
+
         --print('[ulc:vehDrive] My vehicle is driving.')
         parked = false
         if MyVehicle and MyVehicleConfig.parkConfig.usePark then

--- a/ulc/config.lua
+++ b/ulc/config.lua
@@ -61,6 +61,56 @@ Config = {
         maxExpiration = 8,
     },
 
+    -- Fake Environmental Light Config;
+    -- Lets a light-head extra (e.g. a TKD or alley light) be toggled as a
+    -- pure visual mesh, without the vehicle's real environmental lighting
+    -- actually running. A soft "spill" bulb of light is drawn near the
+    -- vehicle opposite the light head to sell the effect, saving on
+    -- running full environmental extras/sirens.
+    FakeEnvSettings = {
+        -- global master switch. false = feature is fully disabled for every
+        -- vehicle regardless of what any individual vehicle's fakeEnvConfig
+        -- says. Each vehicle still needs its own fakeEnvConfig.useFakeEnv = true
+        -- on top of this - this is just the server-wide kill switch.
+        enabled = true,
+        defaultKeys = {
+            left = 'NUMPAD7',
+            tk = 'NUMPAD8',
+            right = 'NUMPAD9',
+        },
+        -- color of the fake light (r, g, b, 0-255)
+        color = { r = 255, g = 244, b = 214 },
+        -- how far out to the side the left/right lights sit (meters)
+        sideDistance = 5.0,
+        -- how far out in front the tk (take-down) light sits (meters)
+        frontDistance = 8.0,
+        -- how high above the vehicle's position the light sits (meters)
+        heightOffset = 1.2,
+        -- size of the light's sphere of influence (meters) - this is the
+        -- "range" the native actually expects, bigger = a larger, further-
+        -- reaching pool of light
+        lightRange = 15.0,
+        -- brightness multiplier for the light
+        lightIntensity = 4.0,
+
+        -- stop drawing (not toggling, just rendering) past this distance from the player, for performance
+        drawRange = 30.0,
+    },
+
+    -- Horn Hold Timing Config;
+    -- global defaults for the horn-hold extras feature (c_horn.lua).
+    -- both can be overridden per-vehicle via MyVehicleConfig.hornConfig.holdDelay
+    -- and MyVehicleConfig.hornConfig.extraHoldTime
+    HornSettings = {
+        -- delay after pressing the horn key before horn extras turn on, in milliseconds
+        -- 0 = instant, same as legacy behavior
+        defaultHoldDelay = 500,
+        -- how long horn extras stay on after releasing the horn key, in seconds
+        -- 0 = instant restore, same as legacy behavior
+        defaultExtraHoldTime = 5,
+    },
+
+
     -- Import confiurations here
     -- Add the resource names of vehicle resources that include a ulc.lua config file
     ExternalVehResources = {

--- a/ulc/fxmanifest.lua
+++ b/ulc/fxmanifest.lua
@@ -35,12 +35,12 @@ client_scripts {
 	'client/c_blackout.lua',
 	'client/c_cruise.lua',
 	'client/c_horn.lua',
+	'client/c_lights.lua',
 	'client/c_park.lua',
 	'client/c_doors.lua',
 	'client/c_reverse.lua',
 	'client/c_stages.lua',
 	'client/c_beeps.lua',
-	'client/c_signals.lua'
 
 }
 
@@ -48,4 +48,5 @@ server_scripts {
 	'server/s_main.lua',
 	'server/s_main.js',
 	'server/s_blackout.lua',
+	'server/s_lights.lua',
 }

--- a/ulc/server/s_lights.lua
+++ b/ulc/server/s_lights.lua
@@ -1,0 +1,96 @@
+--[[
+  Fake Environmental Lights - Server
+  -----------------------------------
+  No gameplay logic runs here - the actual light toggle/sync happens
+  client-side via entity state bags (see client/c_lights.lua), which
+  replicate automatically without needing a manual relay.
+
+  This file just validates config.lua's FakeEnvSettings on startup, and
+  validates each vehicle's fakeEnvConfig as it's reported in by clients,
+  reusing the same ulc:error / ulc:warn events s_main.lua uses so problems
+  show up consistently in the server console.
+]]
+
+local VALID_DIRECTIONS = { left = true, tk = true, right = true }
+
+local function isColorComponentValid(n)
+  return type(n) == 'number' and n >= 0 and n <= 255
+end
+
+-------------------
+-- Global config validation (runs once on resource start)
+-------------------
+
+CreateThread(function()
+  local s = Config.FakeEnvSettings
+  if not s then
+    TriggerEvent('ulc:error', 'Config.FakeEnvSettings is missing - fake environmental lights will not work.')
+    return
+  end
+
+  if type(s.enabled) ~= 'boolean' then
+    TriggerEvent('ulc:error', 'Config.FakeEnvSettings.enabled must be true or false.')
+  end
+
+  if not (isColorComponentValid(s.color.r) and isColorComponentValid(s.color.g) and isColorComponentValid(s.color.b)) then
+    TriggerEvent('ulc:error', 'Config.FakeEnvSettings.color values must each be between 0 and 255.')
+  end
+
+  if s.sideDistance < 0 or s.frontDistance < 0 or s.lightRange < 0 or s.lightIntensity < 0
+    or s.drawRange < 0 then
+    TriggerEvent('ulc:error',
+      'Config.FakeEnvSettings sideDistance/frontDistance/lightRange/lightIntensity/drawRange cannot be negative.')
+  end
+
+  for direction, key in pairs(s.defaultKeys) do
+    if not VALID_DIRECTIONS[direction] then
+      TriggerEvent('ulc:error',
+        'Config.FakeEnvSettings.defaultKeys has an invalid direction "' .. tostring(direction) .. '". Must be left, tk, or right.')
+    end
+  end
+
+  if not Config.HornSettings then
+    TriggerEvent('ulc:error', 'Config.HornSettings is missing - horn hold timing will fall back to instant on/off.')
+  elseif Config.HornSettings.defaultHoldDelay < 0 or Config.HornSettings.defaultExtraHoldTime < 0 then
+    TriggerEvent('ulc:error', 'Config.HornSettings hold/extra times cannot be negative.')
+  end
+end)
+
+-------------------
+-- Per-vehicle config validation
+-------------------
+-- clients call this once after loading MyVehicleConfig for a vehicle that
+-- has fakeEnvConfig.useFakeEnv = true, so misconfigured vehicle resources
+-- get flagged in the server console the same way other ULC config issues do
+
+RegisterNetEvent('ulc:lights:reportConfig')
+AddEventHandler('ulc:lights:reportConfig', function(resourceName, fakeEnvConfig)
+  if not fakeEnvConfig or not fakeEnvConfig.useFakeEnv then return end
+
+  if not fakeEnvConfig.lights or #fakeEnvConfig.lights == 0 then
+    TriggerEvent('ulc:warn',
+      'A config in "' .. tostring(resourceName) .. '" uses Fake Env Lights, but no lights were specified (lights = {}).')
+    return
+  end
+
+  local seenDirections = {}
+
+  for _, light in pairs(fakeEnvConfig.lights) do
+    if type(light.extra) ~= 'number' then
+      TriggerEvent('ulc:error',
+        'A config in "' .. tostring(resourceName) .. '" has a fakeEnvConfig light with a missing/invalid extra number.')
+    end
+
+    if not VALID_DIRECTIONS[light.direction] then
+      TriggerEvent('ulc:error',
+        'A config in "' .. tostring(resourceName) .. '" has a fakeEnvConfig light with an invalid direction "' ..
+        tostring(light.direction) .. '". Must be left, tk, or right.')
+    elseif seenDirections[light.direction] then
+      TriggerEvent('ulc:warn',
+        'A config in "' .. tostring(resourceName) .. '" has more than one fakeEnvConfig light using direction "' ..
+        light.direction .. '" - only the last one registered will be reachable by its keybind.')
+    else
+      seenDirections[light.direction] = true
+    end
+  end
+end)


### PR DESCRIPTION
## Summary

Three related pieces of work, all around `hornConfig`/Intersection
Mode, plus a new opt-in lighting feature:

1. Fixes a state-corruption bug in horn extras restore/hold timing
2. Locks out every other source of extra changes while horn extras
   are active, so nothing can fight the pattern mid-honk
3. Adds a new fake environmental ("scene") light feature for
   TKD/alley lights, with an explicit exception to #2 so scene lights
   stay usable during horn hold

Targeting `develop` per CONTRIBUTING.md.

---

## 1. Horn extras bug fix (`c_horn.lua`)

**The bug:** `SetHornExtras(0)` re-captured "original" extra state on
every press, including re-presses while extras were already active.
That meant mashing/re-tapping the horn key overwrote the real
pre-horn state with the horn-on state, so whatever the restore did on
final release could leave extras in the wrong config - not
necessarily stuck on, just not what they were before the horn was
touched.

**The fix:** split `SetHornExtras` into `ApplyHornExtrasOn()` and
`RestoreHornExtrasOff()`, both gated by a new `hornActive` flag so the
original state is captured exactly once (on the transition into
"active") and restored exactly once. Re-pressing while already active
is now a no-op for capture/apply.

Also cleaned up the hold timing: every release starts exactly one
`extraHoldTime` countdown. A press/release before it fires cancels it
(via the existing generation counter) and the next release starts a
fresh one - so hold time can't stack or accumulate across repeated
honks, it just always restarts from full.

No config changes here, drop-in for existing setups.

## 2. Lock extras during horn hold (`c_buttons.lua`, `c_horn.lua`, `c_park.lua`)

Added `ULC:IsHornExtrasActive()` (`c_horn.lua`) so other scripts can
check whether horn extras currently own the vehicle.

`ULC:SetStage()` in `c_buttons.lua` - the single function every
button, stage key, park pattern, blackout, and default-stage call
routes through - now refuses to change extras while
`IsHornExtrasActive()` is true, logging why. Added a `hornOverride`
param so specific callers can bypass it:
- `c_horn.lua`'s own on/off calls (has to control its own extras)
- the new fake env light toggle, see below

Since this covers `SetStage` centrally, it protects buttons/stage
keys/park pattern/blackout/defaults without touching any of those
files individually. `c_park.lua` also got an explicit early-return in
`ulc:vehPark`/`ulc:vehDrive` ahead of that - redundant now, but left
in as a documented guard at the call site. Fine to drop if you'd
rather the lock live in one place only.

## 3. Fake environmental (scene) lights - new feature (`c_lights.lua`, `s_lights.lua`, `config.lua`, `example.ulc.lua`)

Opt-in, defaults off, no effect on existing vehicle configs.

Toggles a light-head extra's mesh only (no real environmental extra
running behind it) and draws a `DrawLightWithRange` point light near
the vehicle in that direction - left/right offset to the side, tk
offset forward, raised above the vehicle. Meant for TKDs/alleys where
running a full environmental extra constantly isn't worth the cost.
Synced to nearby players via an entity state bag on the vehicle so
passengers/bystanders see the same light, not just the driver.

- New `Config.FakeEnvSettings` in `config.lua`: global enable switch,
  default keybinds (NUMPAD7/8/9, rebindable in FiveM's keybind
  settings), color, `sideDistance`/`frontDistance`/`heightOffset` for
  placement, `lightRange`/`lightIntensity` for size/brightness,
  `drawRange` for draw-distance cutoff.
- New per-vehicle `fakeEnvConfig`: `useFakeEnv` + a `lights` array of
  `{ extra, direction }` (`direction` is `'left'`, `'right'`, or
  `'tk'`).
- `s_lights.lua` validates `Config.FakeEnvSettings` on resource start
  and validates each vehicle's `fakeEnvConfig` as clients report it
  in (missing lights, invalid/duplicate directions, bad extra
  numbers), reusing the existing `ulc:error`/`ulc:warn` events so
  problems surface the same way other ULC config issues do.
- Scene lights bypass the horn lock from #2 on purpose
  (`hornOverride = true` on that one `SetStage` call) - a lot of
  servers use scene lights independently of Intersection Mode, so
  they stay toggleable no matter what horn extras are doing. Worth a
  note in review: if a fake env light's extra number is ever reused
  as one of the vehicle's `hornConfig` extras, toggling it manually
  mid-hold won't be reflected in the horn's saved restore state - not
  an issue with separate extra numbers, which is the expected setup.

`example.ulc.lua` updated with the new `fakeEnvConfig` block and the
optional `hornConfig.holdDelay`/`extraHoldTime` per-vehicle overrides.

## Config changes

- `hornConfig`: optional `holdDelay`, `extraHoldTime` (nil = fall
  back to `Config.HornSettings` global defaults - existing configs
  unaffected)
- `config.lua`: new `Config.FakeEnvSettings` block
- Per-vehicle: new optional `fakeEnvConfig` block

## Testing

Tested locally on [24sorentom] - My own vehicle. Haven't specifically tested
park pattern sync (`useSync`) across multiple synced vehicles while
horn extras are active on one of them - flagging in case that's worth
a second look before merge.

- [x] Horn hold restores correct original extras after rapid re-presses
- [x] Hold time doesn't stack on repeated press/release
- [x] Buttons/stage keys/park pattern locked out during horn hold,
      resume correctly after
- [x] Scene lights still toggle during horn hold
- [ ] Park pattern sync across multiple vehicles while horn active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable fake environmental lighting for left, take-down, and right-facing vehicle lights.
  * Added customizable key bindings, colors, brightness, range, and visibility distance.
  * Added configurable horn hold delays and extra-light restoration timing.

* **Bug Fixes**
  * Prevented parking, driving, and stage changes from interrupting active horn lighting.
  * Improved horn-light state restoration and prevented conflicting delayed actions.

* **Validation**
  * Added configuration checks and warnings for invalid lighting, horn timing, and vehicle settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->