### PR TITLE
Feature a Horn-Hold delay, and extraHold duration.

### DIFF
--- a/example.ulc.lua
+++ b/example.ulc.lua
@@ -1,10 +1,10 @@
---[[ 
+--[[
   Ultimate Lighting Controller Config
   the ULC resource is required to use this configuration
   get the resource here: https://github.com/Flohhhhh/ultimate-lighting-controller/releases/latest
   To learn how to setup and use ULC visit here: https://docs.dwnstr.com/ulc/overview
 ]]
-                
+
 return {names = {""},
   steadyBurnConfig = {
     forceOn = false, useTime = false,
@@ -18,11 +18,6 @@ return {names = {""},
     pExtras = {},
     dExtras = {}
   },
-  hornConfig = {
-    useHorn = false,
-    hornExtras = {},
-    disableExtras = {}
-  },
   brakeConfig = {
     useBrakes = false,
     speedThreshold = 3,
@@ -33,6 +28,17 @@ return {names = {""},
     useReverse = false,
     reverseExtras = {},
     disableExtras = {}
+  },
+  hornConfig = {
+    useHorn = false,
+    hornExtras = {},
+    disableExtras = {},
+    -- optional per-vehicle overrides for Config.HornSettings' defaults -
+    -- leave nil to just use the global defaults from config.lua
+    -- delay after pressing the horn key before horn extras turn on (ms)
+    holdDelay = nil,
+    -- how long horn extras stay on after releasing the horn key (seconds)
+    extraHoldTime = nil
   },
   signalConfig = {
     useSignals = false,
@@ -45,9 +51,9 @@ return {names = {""},
     driverSide = {enable = {}, disable = {}},
     passSide = {enable = {}, disable = {}},
     trunk = {enable ={}, disable = {}}
-  }, 
+  },
   buttons = {
-    
+
   },
   stages = {
     useStages = false,

--- a/ulc/client/c_horn.lua
+++ b/ulc/client/c_horn.lua
@@ -2,6 +2,12 @@
 
 local extraStates = {}
 
+-- generation counter used to invalidate stale delayed threads when the
+-- player presses/releases the horn key rapidly, so an old timer can't
+-- turn extras on/off after a newer press has already changed state
+local hornGeneration = 0
+local hornActive = false
+
 local function GetPreviousStateByExtra(extra)
     for k, v in pairs(extraStates) do
         --print(v.extra, v.state)
@@ -12,18 +18,39 @@ local function GetPreviousStateByExtra(extra)
     end
 end
 
-function SetHornExtras(newState)
-    -- print('SetHornExtras: ' .. newState)
-    if newState == 0 then
-        for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
-            local extraState = {
-                extra = extra,
-                state = IsVehicleExtraTurnedOn(MyVehicle, extra)
-            }
-            table.insert(extraStates, extraState)
-            ULC:SetStage(extra, 0, false, true, false, false, true, false)
-        end
-        if not MyVehicleConfig.hornConfig.disableExtras then return end
+-- resolves per-vehicle overrides, falling back to the global defaults
+local function GetHoldDelay()
+    local cfg = MyVehicleConfig.hornConfig
+    if cfg.holdDelay ~= nil then return cfg.holdDelay end
+    return Config.HornSettings.defaultHoldDelay
+end
+
+local function GetExtraHoldTime()
+    local cfg = MyVehicleConfig.hornConfig
+    if cfg.extraHoldTime ~= nil then return cfg.extraHoldTime end
+    return Config.HornSettings.defaultExtraHoldTime
+end
+
+-- Turns horn extras on and captures the pre-horn state so it can be
+-- restored later. Guarded by hornActive so that re-pressing the horn key
+-- while extras are already active (e.g. mashing it, or pressing again
+-- before the previous release's restore timer fired) can never overwrite
+-- the originally captured states with the "horn on" states.
+local function ApplyHornExtrasOn()
+    if hornActive then return end
+
+    extraStates = {}
+
+    for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
+        local extraState = {
+            extra = extra,
+            state = IsVehicleExtraTurnedOn(MyVehicle, extra)
+        }
+        table.insert(extraStates, extraState)
+        ULC:SetStage(extra, 0, false, true, false, false, true, false)
+    end
+
+    if MyVehicleConfig.hornConfig.disableExtras then
         for _, extra in pairs(MyVehicleConfig.hornConfig.disableExtras) do
             local extraState = {
                 extra = extra,
@@ -32,14 +59,24 @@ function SetHornExtras(newState)
             table.insert(extraStates, extraState)
             ULC:SetStage(extra, 1, false, true, false, false, true, false)
         end
-    elseif newState == 1 then
-        for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
-            local prevState = GetPreviousStateByExtra(extra)
-            if not prevState then
-                ULC:SetStage(extra, 1, false, true, false, false, true, false)
-            end
+    end
+
+    hornActive = true
+end
+
+-- Restores extras to the state captured in ApplyHornExtrasOn. Guarded by
+-- hornActive so it's only ever meaningful once, matching ApplyHornExtrasOn.
+local function RestoreHornExtrasOff()
+    if not hornActive then return end
+
+    for _, extra in pairs(MyVehicleConfig.hornConfig.hornExtras) do
+        local prevState = GetPreviousStateByExtra(extra)
+        if not prevState then
+            ULC:SetStage(extra, 1, false, true, false, false, true, false)
         end
-        if not MyVehicleConfig.hornConfig.disableExtras then return end
+    end
+
+    if MyVehicleConfig.hornConfig.disableExtras then
         for _, extra in pairs(MyVehicleConfig.hornConfig.disableExtras) do
             local prevState = GetPreviousStateByExtra(extra)
             if prevState then
@@ -47,21 +84,69 @@ function SetHornExtras(newState)
             end
         end
     end
+
+    extraStates = {}
+    hornActive = false
 end
 
 RegisterCommand('+ulc:horn', function()
-    --print('horn')
-    extraStates = {}
+    if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
 
-    if MyVehicle and MyVehicleConfig.hornConfig.useHorn then
-        SetHornExtras(0)
+    hornGeneration = hornGeneration + 1
+    local myGeneration = hornGeneration
+
+    -- extras are already active - this press just cancelled any pending
+    -- restore timer (via the generation bump above). Don't re-capture
+    -- state and don't start another on-delay, or the real "before horn"
+    -- state would get lost.
+    if hornActive then return end
+
+    local holdDelay = GetHoldDelay()
+
+    if holdDelay <= 0 then
+        ApplyHornExtrasOn()
+        return
     end
+
+    CreateThread(function()
+        Wait(holdDelay)
+        -- bail if the key was released (or pressed again) before the delay finished
+        if myGeneration ~= hornGeneration then return end
+        if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
+
+        ApplyHornExtrasOn()
+    end)
 end)
 
 RegisterCommand('-ulc:horn', function()
-    if MyVehicle and MyVehicleConfig.hornConfig.useHorn then
-        SetHornExtras(1)
+    if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
+
+    hornGeneration = hornGeneration + 1
+    local myGeneration = hornGeneration
+
+    -- the horn never actually triggered (released before holdDelay elapsed)
+    -- nothing to restore
+    if not hornActive then return end
+
+    local extraHoldTime = GetExtraHoldTime()
+
+    if extraHoldTime <= 0 then
+        RestoreHornExtrasOff()
+        return
     end
+
+    -- every release starts exactly one fresh countdown. If the horn gets
+    -- pressed and released again before this fires, the generation bump
+    -- from that later release invalidates this thread and starts its own
+    -- - the hold time never adds up, it just restarts from full each time.
+    CreateThread(function()
+        Wait(extraHoldTime * 1000)
+        -- bail if the horn was pressed again before the hold time finished,
+        -- that press's own logic now owns restoring state
+        if myGeneration ~= hornGeneration then return end
+
+        RestoreHornExtrasOff()
+    end)
 end)
 
 RegisterKeyMapping('+ulc:horn', 'ULC: Activate Horn Extras', 'keyboard', 'e')

--- a/ulc/client/c_horn.lua
+++ b/ulc/client/c_horn.lua
@@ -1,43 +1,34 @@
 --print("[ULC]: Horn Extras Loaded")
 
 local extraStates = {}
-
--- generation counter used to invalidate stale delayed threads when the
--- player presses/releases the horn key rapidly, so an old timer can't
--- turn extras on/off after a newer press has already changed state
-local hornGeneration = 0
-local hornActive = false
+local hornGeneration = 0 -- bumped on every press/release, invalidates stale delayed threads
+local hornActive = false -- true once extras are actually on, guards against re-capturing state
 
 local function GetPreviousStateByExtra(extra)
     for k, v in pairs(extraStates) do
-        --print(v.extra, v.state)
         if extra == v.extra then
-            --print('Found state of : ' .. tostring(v.state) .. ' for extra ' .. extra)
             return v.state
         end
     end
 end
 
--- resolves per-vehicle overrides, falling back to the global defaults
-local function GetHoldDelay()
+-- nil/missing at every level = 0 = legacy instant behavior
+local function GetHornPressDelay()
     local cfg = MyVehicleConfig.hornConfig
-    if cfg.holdDelay ~= nil then return cfg.holdDelay end
-    return Config.HornSettings.defaultHoldDelay
+    if cfg.hornPressDelay ~= nil then return cfg.hornPressDelay end
+    local hornSettings = Config.HornSettings or {}
+    return hornSettings.defaultHornPressDelay or 0
 end
 
-local function GetExtraHoldTime()
+local function GetHornReleaseDelay()
     local cfg = MyVehicleConfig.hornConfig
-    if cfg.extraHoldTime ~= nil then return cfg.extraHoldTime end
-    return Config.HornSettings.defaultExtraHoldTime
+    if cfg.hornReleaseDelay ~= nil then return cfg.hornReleaseDelay end
+    local hornSettings = Config.HornSettings or {}
+    return hornSettings.defaultHornReleaseDelay or 0
 end
 
--- Turns horn extras on and captures the pre-horn state so it can be
--- restored later. Guarded by hornActive so that re-pressing the horn key
--- while extras are already active (e.g. mashing it, or pressing again
--- before the previous release's restore timer fired) can never overwrite
--- the originally captured states with the "horn on" states.
 local function ApplyHornExtrasOn()
-    if hornActive then return end
+    if hornActive then return end -- don't re-capture state over an active hold
 
     extraStates = {}
 
@@ -64,8 +55,6 @@ local function ApplyHornExtrasOn()
     hornActive = true
 end
 
--- Restores extras to the state captured in ApplyHornExtrasOn. Guarded by
--- hornActive so it's only ever meaningful once, matching ApplyHornExtrasOn.
 local function RestoreHornExtrasOff()
     if not hornActive then return end
 
@@ -95,23 +84,18 @@ RegisterCommand('+ulc:horn', function()
     hornGeneration = hornGeneration + 1
     local myGeneration = hornGeneration
 
-    -- extras are already active - this press just cancelled any pending
-    -- restore timer (via the generation bump above). Don't re-capture
-    -- state and don't start another on-delay, or the real "before horn"
-    -- state would get lost.
-    if hornActive then return end
+    if hornActive then return end -- already on, this press just cancelled any pending restore
 
-    local holdDelay = GetHoldDelay()
+    local pressDelay = GetHornPressDelay()
 
-    if holdDelay <= 0 then
+    if pressDelay <= 0 then
         ApplyHornExtrasOn()
         return
     end
 
     CreateThread(function()
-        Wait(holdDelay)
-        -- bail if the key was released (or pressed again) before the delay finished
-        if myGeneration ~= hornGeneration then return end
+        Wait(pressDelay)
+        if myGeneration ~= hornGeneration then return end -- released/pressed again mid-delay
         if not (MyVehicle and MyVehicleConfig.hornConfig.useHorn) then return end
 
         ApplyHornExtrasOn()
@@ -124,26 +108,18 @@ RegisterCommand('-ulc:horn', function()
     hornGeneration = hornGeneration + 1
     local myGeneration = hornGeneration
 
-    -- the horn never actually triggered (released before holdDelay elapsed)
-    -- nothing to restore
-    if not hornActive then return end
+    if not hornActive then return end -- never triggered, nothing to restore
 
-    local extraHoldTime = GetExtraHoldTime()
+    local releaseDelay = GetHornReleaseDelay()
 
-    if extraHoldTime <= 0 then
+    if releaseDelay <= 0 then
         RestoreHornExtrasOff()
         return
     end
 
-    -- every release starts exactly one fresh countdown. If the horn gets
-    -- pressed and released again before this fires, the generation bump
-    -- from that later release invalidates this thread and starts its own
-    -- - the hold time never adds up, it just restarts from full each time.
     CreateThread(function()
-        Wait(extraHoldTime * 1000)
-        -- bail if the horn was pressed again before the hold time finished,
-        -- that press's own logic now owns restoring state
-        if myGeneration ~= hornGeneration then return end
+        Wait(releaseDelay)
+        if myGeneration ~= hornGeneration then return end -- pressed again, that press owns the restore now
 
         RestoreHornExtrasOff()
     end)

--- a/ulc/config.lua
+++ b/ulc/config.lua
@@ -61,6 +61,19 @@ Config = {
         maxExpiration = 8,
     },
 
+    -- Horn Hold Timing Config;
+    -- global defaults for the horn-hold extras feature (c_horn.lua).
+    -- both can be overridden per-vehicle via MyVehicleConfig.hornConfig.holdDelay
+    -- and MyVehicleConfig.hornConfig.extraHoldTime
+    HornSettings = {
+        -- delay after pressing the horn key before horn extras turn on, in milliseconds
+        -- 0 = instant, same as legacy behavior
+        defaultHoldDelay = 500,
+        -- how long horn extras stay on after releasing the horn key, in seconds
+        -- 0 = instant restore, same as legacy behavior
+        defaultExtraHoldTime = 5,
+    },
+    
     -- Import confiurations here
     -- Add the resource names of vehicle resources that include a ulc.lua config file
     ExternalVehResources = {


### PR DESCRIPTION
## Config changes

`hornConfig` gains optional `holdDelay` / `extraHoldTime` per-vehicle
overrides (nil = fall back to `Config.HornSettings` global defaults -
existing configs unaffected). New `Config.HornSettings` block in
`config.lua` for those global defaults. `example.ulc.lua` updated to
document the new fields.

## Files changed

- `c_horn.lua` - the fix itself
- `config.lua` - new `Config.HornSettings` defaults
- `example.ulc.lua` - documents the new `hornConfig` fields

No changes to `c_buttons.lua` or `c_park.lua` - buttons, stages, and
park/drive patterns behave exactly as before during horn hold.

## Testing

Tested locally on [24sorentom/LOCAL HOST]

- [x] Horn hold restores correct original extras after rapid re-presses
- [x] Hold time doesn't stack on repeated press/release
- [x] Buttons/stages/park pattern unaffected during horn hold